### PR TITLE
Fix pandas SettingWithCopyWarning in pandas

### DIFF
--- a/app/helpers/parse_dd20.py
+++ b/app/helpers/parse_dd20.py
@@ -303,7 +303,7 @@ class DD20StationDataframeParser:
                 & ~self.__df_station_source[self.__acline_name_col_nm].isin(
                     acline_parallel_dd20_names
                 )
-            ]
+            ].copy()
             """
             4. cleaning frame by:
             - Removing (N) from values in AC-line name column
@@ -561,7 +561,7 @@ class DD20LineDataframeParser:
                         ".", na=False
                     )
                 )
-            ]
+            ].copy()
             """
             Cleaning frame by:
             - Removing (N) from values in AC-line name column

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: conductor-data-provider
 description: A helm chart for energinet-singularity/conductor-data-provider
-version: 1.1.1
+version: 1.1.2
 
 dependencies:
   - name: file-mover

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/energinet-singularity/conductor-data-provider/energinet-singularity/conductor-data-provider
   pullPolicy: IfNotPresent
-  tag: "1.1.1"
+  tag: "1.1.2"
 
 # Setup PVC
 conductorInputVolume: 


### PR DESCRIPTION
This is a quick fix of the warnings from Pandas regarding SettingsWithCopyWarning. Solved by specifying ".copy()" in two locations.

Solves #17.

Category:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation update

Checklist:

- [x] I have bumped all relevant version numbers
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have documented my changes if this is needed
- [x] I have described my changes in the "description of your changes" field
- [x] I have tested this change on a running cluster 
- [ ] I have created/corrected automated tests related to the changes, if possible/necessary
- [x] I have checked that new and existing unit tests pass locally with my changes
- [x] I have squashed commits if necessary
